### PR TITLE
Select first point in bucket when all areas are zero

### DIFF
--- a/lttb.go
+++ b/lttb.go
@@ -69,7 +69,7 @@ func LTTB(data []Point, threshold int) []Point {
 		pointAX := data[a].X
 		pointAY := data[a].Y
 
-		var maxArea float64
+		maxArea := -1.0
 
 		var nextA int
 		for ; rangeOffs < rangeTo; rangeOffs++ {

--- a/lttb_test.go
+++ b/lttb_test.go
@@ -1,0 +1,36 @@
+package lttb
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestPointSelectionWithZeroArea is a regression test for the
+// correct selection of a "b" point in a bucket where all computed
+// areas have a value of zero.
+func TestPointSelectionWithZeroArea(t *testing.T) {
+	data := []Point{
+		{0, 0}, // sentinel value
+		{1299456, 116.3707},
+		{1300320, 116.3752}, // a
+		{1301184, 116.3648}, // b --> Should be selected even when triangle area is zero.
+		{1302048, 116.3544}, // c
+		{1302912, 116.3328},
+		{1306368, 116.3277},
+		{1307232, 116.2676},
+	}
+
+	want := []Point{
+		{0, 0},
+		{1299456, 116.3707},
+		{1300320, 116.3752},
+		{1301184, 116.3648},
+		{1302048, 116.3544},
+		{1306368, 116.3277},
+		{1307232, 116.2676},
+	}
+
+	if have := LTTB(data, 7); !reflect.DeepEqual(have, want) {
+		t.Errorf("\nhave %v\nwant %v", have, want)
+	}
+}


### PR DESCRIPTION
This commit fixes a bug that manifested when the all computed triangle
areas with a bucket's candidates were zero and the chosen point was the
first point in the original data.