### PR TITLE
Fixes go module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/atuleu/go-lttb
+module github.com/dgryski/go-lttb
 
 go 1.19
 


### PR DESCRIPTION
This commit fixes the go module path introduced in #5.